### PR TITLE
게시글 제목 클릭 시 상세 페이지로 이동 기능 추가

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,10 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# HTTP client and HTML parser for web scraping
+gem "faraday"
+gem "nokogiri"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,12 @@ GEM
       railties (>= 5.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -164,6 +170,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.6)
       date
       net-protocol
@@ -410,9 +418,11 @@ DEPENDENCIES
   debug
   factory_bot_rails
   faker
+  faraday
   importmap-rails
   jbuilder
   kamal
+  nokogiri
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2)

--- a/Parsing.md
+++ b/Parsing.md
@@ -1,5 +1,24 @@
 # 원광대학교 사이버캠퍼스 페이지 파싱 구조 분석
 
+## 실제 URL 예시
+
+### 베이스 URL
+- 사이버캠퍼스: `https://cyber.wku.ac.kr/`
+
+### 게시글 목록 페이지
+- 목록 페이지: `https://cyber.wku.ac.kr/Cyber/ComBoard_V005/Content/list.jsp?gid=1115983888724&bid=1115985252888`
+- 페이지 지정: `https://cyber.wku.ac.kr/Cyber/ComBoard_V005/Content/list.jsp?gid=1115983888724&bid=1115985252888&page=2`
+- 검색 결과: `https://cyber.wku.ac.kr/Cyber/ComBoard_V005/Content/list.jsp?gid=1115983888724&bid=1115985252888&sField=TITLE&sKey=검색어`
+
+### 게시글 상세 페이지
+- POST 방식(직접 URL로 접근 불가): `https://cyber.wku.ac.kr/Cyber/ComBoard_V005/Content/view.jsp`
+  - POST 파라미터: `gid=1115983888724&bid=1115985252888&cid=1742956026481&lpage=1`
+- GET 방식(접근 가능): `https://cyber.wku.ac.kr/Cyber/ComBoard_V005/Content/print.jsp?gid=1115983888724&bid=1115985252888&cid=1742956026481`
+
+### 이미지 URL
+- 예시: `https://cyberimg.wku.ac.kr/ComBoard/img/upload/1115983888724/1115985252888/2025/03/1742956026481/org/0003.jpg`
+- 구조: `https://cyberimg.wku.ac.kr/ComBoard/img/upload/[gid]/[bid]/[year]/[month]/[cid]/org/[filename]`
+
 ## 1. 게시글 목록 구조 (list.jsp)
 
 ### 게시글 목록 구조:

--- a/Parsing.md
+++ b/Parsing.md
@@ -1,0 +1,71 @@
+# 원광대학교 사이버캠퍼스 페이지 파싱 구조 분석
+
+## 1. 게시글 목록 구조 (list.jsp)
+
+### 게시글 목록 구조:
+- 공지사항: `<tr class="notice notice-view">`
+- 일반게시글: `<tr>` (class 없음)
+
+### 게시글 항목 구조:
+- 공지사항 태그: `td:nth-child(1) > span.label`
+- 작성자: `td:nth-child(2)`
+- 제목: `td:nth-child(3) > a`
+- 날짜: `td:nth-child(4)`
+- 조회수: `td:nth-child(5)`
+- 파일첨부: `td:nth-child(6) > span.label`
+
+### 게시글 링크:
+- 원본 형식: `JavaScript:viewGo("1742804766028", 1);`
+- 링크 ID 추출 방법: `viewGo("ID", 1)` 에서 ID 부분을 추출
+- POST 방식 접근: `/Cyber/ComBoard_V005/Content/view.jsp` (cid 파라미터 필요)
+- GET 방식 접근: `/Cyber/ComBoard_V005/Content/print.jsp?gid=1115983888724&bid=1115985252888&cid=POST_ID`
+- 필수 폼 파라미터:
+  * gid: 1115983888724 (게시판 그룹 ID)
+  * bid: 1115985252888 (게시판 ID)  
+  * cid: 게시글 ID (viewGo 함수의 첫 번째 파라미터)
+  * lpage: 페이지 번호 (기본값 1)
+
+### 페이지네이션:
+- 형식: `<div class="pagination">` 내부의 `<ul>` `<li>` 요소들
+- 페이지 이동: `JavaScript:listGo(1, 페이지번호);`
+
+### 검색 기능:
+- 검색 폼: 하단의 `<form>` 요소
+- 검색 필드: `select[name='sField']`
+- 검색어: `input[name='sKey']`
+
+## 2. 게시글 상세 페이지 구조 (view.jsp)
+
+### 게시글 메타데이터
+- 작성자: `div.row-fluid div.span12 strong:contains("작성자") + a`
+- 작성자 이메일: `div.row-fluid div.span12 a[href^='mailto:']`
+- 게시글 번호: `div.row-fluid div.span12 strong:contains("NO.") + 텍스트`
+- 조회수: `div.row-fluid div.span12 strong:contains("조회수") + 텍스트`
+- 작성일: `div.row-fluid div.span12 strong:contains("작성일") + 텍스트`
+
+### 첨부파일 정보
+- 첨부파일 링크: `div.row-fluid div.span12 a[href^='javaScript:downGo']`
+- 첨부파일 이름: `div.row-fluid div.span12 a[href^='javaScript:downGo'] strong`
+- 파일 크기: `span#noPrint strong:first-child`
+- 다운로드 횟수: `span#noPrint strong:last-child`
+
+### 게시글 내용
+- 게시글 제목: `div.row-fluid div.span12 p`
+- 게시글 내용 영역: `div.bbs-div-kcy`
+- 실제 내용: `div.bbs-div-kcy table.bbs-form-2017 tbody tr td`
+- 대제목: `div.bbs-div-kcy h1`
+- 소제목: `div.bbs-div-kcy h2`
+- 이미지: `div.bbs-div-kcy img`
+  - 이미지 URL 형식: `https://cyberimg.wku.ac.kr/ComBoard/img/upload/[gid]/[bid]/[year]/[month]/[cid]/org/[filename]`
+
+### 버튼 및 기능
+- 주소복사 버튼: `button[onclick="JavaScript:copyUrl()"]`
+- 인쇄 버튼: `button[onclick='JavaScript:printGo()']`
+- 검색목록 버튼: `button[onclick='JavaScript:listGo(1, 1)']`
+- 전체목록 버튼: `button[onclick="location.href='/Cyber/ComBoard_V005/Content/list.jsp?gid=1115983888724&bid=1115985252888'"]`
+
+### 폼 및 히든 필드
+- 폼 이름: `form[name='view']`
+- 게시판 그룹 ID: `input[name='gid']`
+- 게시판 ID: `input[name='bid']`
+- 게시글 ID: `input[name='cid']`

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,87 @@
+class PostsController < ApplicationController
+  require 'faraday'
+  require 'nokogiri'
+
+  def index
+    # 원광대 사이버캠퍼스 공지사항 URL
+    url = 'https://cyber.wku.ac.kr/Cyber/ComBoard_V005/Content/list.jsp?gid=1115983888724&bid=1115985252888'
+    
+    begin
+      # Faraday를 사용하여 웹 페이지 가져오기
+      response = Faraday.get(url)
+      
+      if response.status == 200
+        # Nokogiri를 사용하여 HTML 파싱
+        doc = Nokogiri::HTML(response.body)
+        
+        # 게시글 목록 추출
+        @posts = []
+        
+        # 공지 게시글
+        doc.css('tr.notice').each do |row|
+          post = {
+            type: row.css('td:nth-child(1) span').text.strip,
+            author: row.css('td:nth-child(2)').text.strip,
+            title: row.css('td:nth-child(3) a').text.strip,
+            date: row.css('td:nth-child(4)').text.strip,
+            views: row.css('td:nth-child(5)').text.strip,
+            has_file: row.css('td:nth-child(6)').text.strip.present?,
+            link_id: row.css('td:nth-child(3) a').attr('href')&.to_s&.match(/viewGo\(\"([^\"]+)\"/)&.captures&.first
+          }
+          
+          @posts << post unless post[:title].empty?
+        end
+        
+        # 일반 게시글
+        doc.css('table.table tbody tr').each do |row|
+          # 헤더 행과 공지 게시글은 건너뜀
+          next if row.css('th').any? || row['class']&.include?('notice')
+          
+          post = {
+            number: row.css('td:nth-child(1)').text.strip,
+            author: row.css('td:nth-child(2)').text.strip,
+            title: row.css('td:nth-child(3) a').text.strip,
+            date: row.css('td:nth-child(4)').text.strip,
+            views: row.css('td:nth-child(5)').text.strip,
+            has_file: row.css('td:nth-child(6) span.label').present?,
+            link_id: row.css('td:nth-child(3) a').attr('href')&.to_s&.match(/viewGo\(\"([^\"]+)\"/)&.captures&.first
+          }
+          
+          @posts << post unless post[:title].empty?
+        end
+      else
+        @error = "페이지를 가져올 수 없습니다. 상태 코드: #{response.status}"
+      end
+    rescue => e
+      @error = "오류가 발생했습니다: #{e.message}"
+    end
+    
+    # 페이지 구조 분석
+    # 웹 페이지 구조 분석:
+    # 
+    # 1. 게시글 목록 구조:
+    #    - 공지사항: <tr class="notice notice-view">
+    #    - 일반게시글: <tr> (class 없음)
+    # 
+    # 2. 게시글 항목 구조:
+    #    - 공지사항 태그: td:nth-child(1) > span.label
+    #    - 작성자: td:nth-child(2)
+    #    - 제목: td:nth-child(3) > a
+    #    - 날짜: td:nth-child(4)
+    #    - 조회수: td:nth-child(5)
+    #    - 파일첨부: td:nth-child(6) > span.label
+    # 
+    # 3. 게시글 링크:
+    #    - 형식: JavaScript:viewGo("1742804766028", 1);
+    #    - 링크 ID 추출 방법: viewGo("ID", 1) 에서 ID 부분을 추출
+    # 
+    # 4. 페이지네이션:
+    #    - 형식: <div class="pagination"> 내부의 <ul> <li> 요소들
+    #    - 페이지 이동: JavaScript:listGo(1, 페이지번호);
+    # 
+    # 5. 검색 기능:
+    #    - 검색 폼: 하단의 <form> 요소
+    #    - 검색 필드: select[name='sField']
+    #    - 검색어: input[name='sKey']
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -72,8 +72,15 @@ class PostsController < ApplicationController
     #    - 파일첨부: td:nth-child(6) > span.label
     # 
     # 3. 게시글 링크:
-    #    - 형식: JavaScript:viewGo("1742804766028", 1);
+    #    - 원본 형식: JavaScript:viewGo("1742804766028", 1);
     #    - 링크 ID 추출 방법: viewGo("ID", 1) 에서 ID 부분을 추출
+    #    - POST 방식 접근: /Cyber/ComBoard_V005/Content/view.jsp (cid 파라미터 필요)
+    #    - GET 방식 접근: /Cyber/ComBoard_V005/Content/print.jsp?gid=1115983888724&bid=1115985252888&cid=POST_ID
+    #    - 필수 폼 파라미터:
+    #      * gid: 1115983888724 (게시판 그룹 ID)
+    #      * bid: 1115985252888 (게시판 ID)  
+    #      * cid: 게시글 ID (viewGo 함수의 첫 번째 파라미터)
+    #      * lpage: 페이지 번호 (기본값 1)
     # 
     # 4. 페이지네이션:
     #    - 형식: <div class="pagination"> 내부의 <ul> <li> 요소들

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,0 +1,2 @@
+module PostsHelper
+end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -32,7 +32,13 @@
               <% end %>
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-              <%= post[:title] %>
+              <% if post[:link_id].present? %>
+                <a href="https://cyber.wku.ac.kr/Cyber/ComBoard_V005/Content/print.jsp?gid=1115983888724&bid=1115985252888&cid=<%= post[:link_id] %>" target="_blank" class="text-blue-600 hover:text-blue-800 hover:underline">
+                  <%= post[:title] %>
+                </a>
+              <% else %>
+                <%= post[:title] %>
+              <% end %>
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
               <%= post[:author] %>
@@ -72,8 +78,15 @@
    - 파일첨부: td:nth-child(6) &gt; span.label
 
 3. 게시글 링크:
-   - 형식: JavaScript:viewGo("1742804766028", 1);
+   - 원본 형식: JavaScript:viewGo("1742804766028", 1);
    - 링크 ID 추출 방법: viewGo("ID", 1) 에서 ID 부분을 추출
+   - POST 방식 접근: /Cyber/ComBoard_V005/Content/view.jsp (cid 파라미터 필요)
+   - GET 방식 접근: /Cyber/ComBoard_V005/Content/print.jsp?gid=1115983888724&bid=1115985252888&cid=POST_ID
+   - 필수 폼 파라미터:
+     * gid: 1115983888724 (게시판 그룹 ID)
+     * bid: 1115985252888 (게시판 ID)  
+     * cid: 게시글 ID (viewGo 함수의 첫 번째 파라미터)
+     * lpage: 페이지 번호 (기본값 1)
 
 4. 페이지네이션:
    - 형식: &lt;div class="pagination"&gt; 내부의 &lt;ul&gt; &lt;li&gt; 요소들

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,88 @@
+<div class="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
+  <h1 class="text-3xl font-bold mb-6">원광대학교 사이버캠퍼스 공지사항</h1>
+  
+  <% if @error.present? %>
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+      <%= @error %>
+    </div>
+  <% end %>
+  
+  <div class="overflow-x-auto">
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead class="bg-gray-50">
+        <tr>
+          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">구분</th>
+          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">제목</th>
+          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">작성자</th>
+          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">작성일</th>
+          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">조회수</th>
+          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">첨부파일</th>
+        </tr>
+      </thead>
+      <tbody class="bg-white divide-y divide-gray-200">
+        <% @posts&.each do |post| %>
+          <tr class="<%= post[:type]&.include?('공지') ? 'bg-gray-50' : '' %>">
+            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+              <% if post[:type].present? %>
+                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
+                  <%= post[:type] %>
+                </span>
+              <% else %>
+                <%= post[:number] %>
+              <% end %>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+              <%= post[:title] %>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+              <%= post[:author] %>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+              <%= post[:date] %>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+              <%= post[:views] %>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+              <% if post[:has_file] %>
+                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                  파일
+                </span>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+  
+  <div class="mt-8 bg-gray-50 p-4 rounded-lg">
+    <h2 class="text-xl font-semibold mb-4">페이지 구조 분석</h2>
+    <pre class="bg-gray-100 p-4 rounded overflow-auto text-xs">
+1. 게시글 목록 구조:
+   - 공지사항: &lt;tr class="notice notice-view"&gt;
+   - 일반게시글: &lt;tr&gt; (class 없음)
+
+2. 게시글 항목 구조:
+   - 공지사항 태그: td:nth-child(1) &gt; span.label
+   - 작성자: td:nth-child(2)
+   - 제목: td:nth-child(3) &gt; a
+   - 날짜: td:nth-child(4)
+   - 조회수: td:nth-child(5)
+   - 파일첨부: td:nth-child(6) &gt; span.label
+
+3. 게시글 링크:
+   - 형식: JavaScript:viewGo("1742804766028", 1);
+   - 링크 ID 추출 방법: viewGo("ID", 1) 에서 ID 부분을 추출
+
+4. 페이지네이션:
+   - 형식: &lt;div class="pagination"&gt; 내부의 &lt;ul&gt; &lt;li&gt; 요소들
+   - 페이지 이동: JavaScript:listGo(1, 페이지번호);
+
+5. 검색 기능:
+   - 검색 폼: 하단의 &lt;form&gt; 요소
+   - 검색 필드: select[name='sField']
+   - 검색어: input[name='sKey']
+    </pre>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  # 게시글 목록 라우팅
+  resources :posts, only: [:index]
+  
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
@@ -10,5 +13,5 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "posts#index"
 end

--- a/script/fetch_page.rb
+++ b/script/fetch_page.rb
@@ -1,12 +1,36 @@
 #!/usr/bin/env ruby
 require 'faraday'
+require 'nokogiri'
 
 url = 'https://cyber.wku.ac.kr/Cyber/ComBoard_V005/Content/list.jsp?gid=1115983888724&bid=1115985252888'
 
 response = Faraday.get(url)
 
 if response.status == 200
-  puts response.body
+  doc = Nokogiri::HTML(response.body)
+  
+  # 첫 번째 링크의 href 추출
+  first_link = doc.css('td:nth-child(3) a').first
+  if first_link
+    href = first_link['href']
+    puts "First link href: #{href}"
+    
+    # viewGo 함수 파라미터 추출
+    if href =~ /viewGo\(\"([^\"]+)\"\s*,\s*(\d+)\)/
+      post_id = $1
+      page = $2
+      puts "Post ID: #{post_id}, Page: #{page}"
+    end
+  end
+  
+  # 폼 요소 찾기
+  form = doc.css('form[name="list"]').first
+  if form
+    puts "\nForm elements:"
+    form.css('input').each do |input|
+      puts "#{input['name']}: #{input['value']}"
+    end
+  end
 else
   puts "Failed with HTTP Status: #{response.status}"
 end

--- a/script/fetch_page.rb
+++ b/script/fetch_page.rb
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+require 'faraday'
+
+url = 'https://cyber.wku.ac.kr/Cyber/ComBoard_V005/Content/list.jsp?gid=1115983888724&bid=1115985252888'
+
+response = Faraday.get(url)
+
+if response.status == 200
+  puts response.body
+else
+  puts "Failed with HTTP Status: #{response.status}"
+end

--- a/spec/helpers/posts_helper_spec.rb
+++ b/spec/helpers/posts_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PostsHelper. For example:
+#
+# describe PostsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PostsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Posts", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/posts/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/posts/index.html.tailwindcss_spec.rb
+++ b/spec/views/posts/index.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "posts/index.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## Summary
- 원광대 사이버캠퍼스 공지사항 게시글 제목 클릭 시 상세 페이지로 이동하는 기능 구현
- POST 방식이 아닌 GET 방식으로 접근 가능한 print.jsp 페이지로 연결
- 페이지 구조 분석 문서에 게시글 링크 접근 방식 상세 정보 추가

## Test plan
- 게시글 제목 클릭 시 새 탭에서 해당 게시글 내용이 정상적으로 표시되는지 확인
- 링크 구조가 올바르게 형성되었는지 확인 (print.jsp 페이지 사용)

🤖 Generated with [Claude Code](https://claude.ai/code)